### PR TITLE
ddu.vimのリンクを修正

### DIFF
--- a/articles/ddu-ui-filer.md
+++ b/articles/ddu-ui-filer.md
@@ -257,7 +257,7 @@ https://github.com/Shougo/ddu-column-filename
 
 - <https://deno.land/>
 - <https://github.com/vim-denops/denops.vim>
-- <https://github.com/vim-denops/ddu.vim>
+- <https://github.com/Shougo/ddu.vim>
 
 ここではプラグインと依存関係はすでにインストール済み、ロード済みとして話を続けます。
 


### PR DESCRIPTION
`ddu.vim` のリンクに誤りがあったので修正しました。